### PR TITLE
Fix broken link for PyWPS main site

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     <li><a href="/pycsw-workshop">workshop</a></li>
   </ul>
 </li>
-<li><a href="http://pywps.wald.intevation.org/">PyWPS</a> - OGC WPS server implementation</li>
+<li><a href="http://pywps.org/">PyWPS</a> - OGC WPS server implementation</li>
 <li><a href="/GeoHealthCheck">GeoHealthCheck</a> - Service Status Checker for OGC Web Services</li>
 <li><a href="http://plugins.qgis.org/plugins/cadtools/">CadTools</a> - Some tools to perform cad like functions in QGIS</li>
 </ul><p>Also join us in irc://freenode.net/#geopython.</p>


### PR DESCRIPTION
index.html still refers to the wald.intevation...PyWPS website, which redirects to a broken link http://pywps.github.io/. Best option here is to link to 
http://pywps.org/ directly (but also fix wald.intevation... there) as in my PR.
